### PR TITLE
Adding `descriptionFile` property to the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ produces:
   - application/json
 ```
 
+> Note: You can also specify a file path in the configuration for your description (i.e. 'README.md')
+
 If you don't start your app with an npm command, then you will need to proved
 the required `info` properties. Or you can just explicitly define them like you
 should anyway.
@@ -143,6 +145,7 @@ var docsPath = path.join(__dirname, 'docs');
 // any other properties put on this object get put directly onto the swagger api doc object
 var docsOptions = {
   definitionsDir: '_definitions', // The relative path to the definitions directory (relative to above path)
+  descriptionFile: 'README.md', // Path of the file used for the API `info.description` property
   pathsDir: '' // The relative path to where the paths will be read from. Default is the root. This will ignore files in the definitionsDir.
 };
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,7 @@
+# This is an example README.md file for this API
+
+Swaggerize-docs is:
+- Cool
+- Awesome
+- Double Cool
+- Written by (99.99%) Keith

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs              = require('fs');
 var path            = require('path');
 var merge           = require('merge');
 var readYaml        = require('./lib/read-yaml');
@@ -32,6 +33,7 @@ function compileDocs(dir, options) {
 
   delete options.definitionsDir;
   delete options.pathsDir;
+  delete options.descriptionFile;
 
   return getApiDocs(dir, apiDocOptions)
     .then(function (api) {
@@ -58,6 +60,12 @@ function getApiDocs(dir, options) {
     })
     .then(function (baseApi) {
       api = baseApi;
+
+      if(options.descriptionFile) {
+        api.info.description = fs
+          .readFileSync(path.resolve(options.descriptionFile), 'utf8');
+      }
+
       return getPaths(
         path.resolve(dir, options.pathsDir),
         options.definitionsDir

--- a/test/fixtures/path-description/index.yaml
+++ b/test/fixtures/path-description/index.yaml
@@ -1,0 +1,5 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Kobol
+  description: README.md

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ describe('swaggerize-docs', function () {
   it('should include a file as a description if the "info.description" field is a path', function () {
     return docs(path.join(__dirname, 'fixtures', 'path-description'), { descriptionFile: 'README.md' })
       .then(function (api) {
-        expect(api.info.description).to.be.equal('README.md');
+        expect(api.info.description.length).to.be.above(9);
       });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,13 @@ describe('swaggerize-docs', function () {
 
   });
 
+  it('should include a file as a description if the "info.description" field is a path', function () {
+    return docs(path.join(__dirname, 'fixtures', 'path-description'), { descriptionFile: 'README.md' })
+      .then(function (api) {
+        expect(api.info.description).to.be.equal('README.md');
+      });
+  });
+
 });
 
 function testApi(endpoint, data) {


### PR DESCRIPTION
Adding `descriptionFile` property to the configuration for specifying a file instead of a string for the `info.description` property
